### PR TITLE
Standard syllabus db

### DIFF
--- a/PainterExtension/SideMenu/standard_syllabus.html
+++ b/PainterExtension/SideMenu/standard_syllabus.html
@@ -10,6 +10,7 @@
     <main class="syllabus-content">
         <!-- Edit Controls -->
         <div id="edit-mode-controls">
+            <button class="update-db-btn standard-button">Update from DB</button>
             <button class="edit-mode-btn standard-button">Edit</button>
             <button class="cancel-btn standard-button" style="display: none;">Cancel</button>
             <button class="done-btn standard-button" style="display: none;">Done</button>

--- a/PainterExtension/SideMenu/standard_syllabus.html
+++ b/PainterExtension/SideMenu/standard_syllabus.html
@@ -10,10 +10,12 @@
     <main class="syllabus-content">
         <!-- Edit Controls -->
         <div id="edit-mode-controls">
-            <button class="update-db-btn standard-button">Update from DB</button>
+            <button class="update-db-btn standard-button" style="display: none;">Update</button>
             <button class="edit-mode-btn standard-button">Edit</button>
             <button class="cancel-btn standard-button" style="display: none;">Cancel</button>
             <button class="done-btn standard-button" style="display: none;">Done</button>
+            <button class="done-btn standard-button" style="display: none;">Done</button>
+            <button class="update-to-db-btn standard-button" style="display: none;">Upload Changes</button>
         </div>
 
         <div id="syllabus-categories">

--- a/PainterExtension/SideMenu/standard_syllabus_page.css
+++ b/PainterExtension/SideMenu/standard_syllabus_page.css
@@ -157,14 +157,13 @@ h2 {
     padding: 6px 12px;
 }
 
-/* Add this with the other button variations */
-.update-db-btn {
+.update-to-db-btn {
     background: #f0f8ff;
     border-color: #b3d4fc;
     color: #0066cc;
 }
 
-.update-db-btn:hover {
+.update-to-db-btn:hover {
     background: #e6f2ff;
     border-color: #99c2ff;
 }

--- a/PainterExtension/SideMenu/standard_syllabus_page.css
+++ b/PainterExtension/SideMenu/standard_syllabus_page.css
@@ -157,6 +157,18 @@ h2 {
     padding: 6px 12px;
 }
 
+/* Add this with the other button variations */
+.update-db-btn {
+    background: #f0f8ff;
+    border-color: #b3d4fc;
+    color: #0066cc;
+}
+
+.update-db-btn:hover {
+    background: #e6f2ff;
+    border-color: #99c2ff;
+}
+
 /* Controls Positioning */
 .category-controls,
 .item-controls {

--- a/PainterExtension/SideMenu/standard_syllabus_page.js
+++ b/PainterExtension/SideMenu/standard_syllabus_page.js
@@ -37,6 +37,7 @@ function loadCourseData(courseId) {
 
 // saves the data to local storage
 function saveCourseData(courseId, data) {
+    syllabusData = data;
     return new Promise((resolve, reject) => {
         const key = `syllabus_${courseId}`;
         const saveObj = { [key]: data };
@@ -131,8 +132,6 @@ function isSyllabusDataEqual(data1, data2) {
 // Load initial data and compare with server data
 async function loadInitialData(courseId) {
     try {
-        // Load local data
-        syllabusData = await loadCourseData(courseId);
         
         // Fetch server data
         const response = await fetch(`https://web.engr.oregonstate.edu/~ludwigo/cs362/api/syllabus-data.php?courseId=${courseId}`);
@@ -148,7 +147,6 @@ async function loadInitialData(courseId) {
         showUpdateButtonIfAppl();
     } catch (error) {
         console.error('Error loading initial data:', error);
-        return await loadCourseData(courseId);
     }
 }
 
@@ -237,13 +235,15 @@ function displaySyllabusData(data) {
 document.addEventListener('DOMContentLoaded', async () => {
 
     // Load saved data including server comparison
-    await loadInitialData(courseId);
+    syllabusData = await loadCourseData(courseId);
     console.log('Loaded data structure:', syllabusData);
 
     // Setup edit controls
     setupEditControls();
 
     displaySyllabusData(syllabusData);
+
+    await loadInitialData(courseId);
 
     // Setup for file uploading
     const uploadBtn = document.getElementById("uploadSyllabusBtn");

--- a/PainterExtension/SideMenu/standard_syllabus_page.js
+++ b/PainterExtension/SideMenu/standard_syllabus_page.js
@@ -1,17 +1,33 @@
 // Storage management functions
 function loadCourseData(courseId) {
-    return new Promise((resolve) => {
+    return new Promise(async (resolve) => {
         const key = `syllabus_${courseId}`;
-        chrome.storage.local.get(key, (result) => {
+        chrome.storage.local.get(key, async (result) => {
             const data = result[key];
-            console.log('Loaded data:', key, data);
+            console.log('Loaded local data:', key, data);
 
-            // Check version and reset if not current
+            // If no data or wrong version, try getting from server first
             if (!data || data.version !== '0.1.1') {
-                const defaultData = getDefaultStructure();
-                saveCourseData(courseId, defaultData);
-                resolve(defaultData);
-                return;
+                try {
+                    // Try to get from server
+                    const response = await fetch(`https://web.engr.oregonstate.edu/~ludwigo/cs362/api/syllabus-data.php?courseId=${courseId}`);
+                    if (!response.ok) {
+                        throw new Error('Network response was not ok');
+                    }
+                    const serverData = await response.json();
+                    
+                    // Save server data locally and return it
+                    await saveCourseData(courseId, serverData);
+                    resolve(serverData);
+                    return;
+                } catch (error) {
+                    console.error('Error fetching from server, using default:', error);
+                    // Fall back to default structure if server fails
+                    const defaultData = getDefaultStructure();
+                    await saveCourseData(courseId, defaultData);
+                    resolve(defaultData);
+                    return;
+                }
             }
 
             resolve(data);
@@ -19,6 +35,7 @@ function loadCourseData(courseId) {
     });
 }
 
+// saves the data to local storage
 function saveCourseData(courseId, data) {
     return new Promise((resolve, reject) => {
         const key = `syllabus_${courseId}`;
@@ -31,11 +48,13 @@ function saveCourseData(courseId, data) {
                 return;
             }
             console.log('Saved data:', key, data);
+            
             resolve(true);
         });
     });
 }
 
+// default structure for the syllabus
 function getDefaultStructure() {
     return {
         version: '0.1.1',
@@ -69,37 +88,102 @@ function getDefaultStructure() {
     };
 }
 
-// Add after storage functions
+// show update button if data is different between local and server
+function showUpdateButtonIfAppl() {
+    const updateBtn = document.querySelector('.update-db-btn');
+    updateBtn.style.display = isSyllabusDataEqual(syllabusData, window.serverSyllabusData) ? 'none' : 'inline';
+}
+function isSyllabusDataEqual(data1, data2) {
+    console.log('Data1:', data1);
+    console.log('Data2:', data2);
+    
+    // Handle null/undefined cases
+    if (!data1 || !data2) return false;
+    
+    // Ensure both have required properties
+    if (!data1.categories || !data2.categories) return false;
+
+    try {
+        // Normalize objects by sorting keys
+        const normalize = (obj) => {
+            if (Array.isArray(obj)) {
+                return obj.map(normalize);
+            }
+            if (obj && typeof obj === 'object') {
+                return Object.keys(obj).sort().reduce((result, key) => {
+                    result[key] = normalize(obj[key]);
+                    return result;
+                }, {});
+            }
+            return obj;
+        };
+
+        const normalized1 = normalize(data1);
+        const normalized2 = normalize(data2);
+        
+        return JSON.stringify(normalized1) === JSON.stringify(normalized2);
+    } catch (e) {
+        console.error('Comparison error:', e);
+        return false;
+    }
+}
+
+// Load initial data and compare with server data
+async function loadInitialData(courseId) {
+    try {
+        // Load local data
+        syllabusData = await loadCourseData(courseId);
+        
+        // Fetch server data
+        const response = await fetch(`https://web.engr.oregonstate.edu/~ludwigo/cs362/api/syllabus-data.php?courseId=${courseId}`);
+        if (!response.ok) {
+            throw new Error('Network response was not ok');
+        }
+        const serverData = await response.json();
+        
+        // Store server data for later comparison
+        window.serverSyllabusData = serverData;
+        console.log('Server data:', serverData);
+        
+        showUpdateButtonIfAppl();
+    } catch (error) {
+        console.error('Error loading initial data:', error);
+        return await loadCourseData(courseId);
+    }
+}
+
+
 let isEditMode = false;
 let backupData = null;
-let data;
+let syllabusData;
 const main = document.getElementById('syllabus-categories');
 const urlParams = new URLSearchParams(window.location.search);
 const courseId = urlParams.get('courseId') || 'unknown';
 
+// setup edit control functions and visibility
 function setupEditControls() {
     const controls = document.getElementById('edit-controls');
     const editBtn = document.querySelector('.edit-mode-btn');
     const cancelBtn = document.querySelector('.cancel-btn');
     const doneBtn = document.querySelector('.done-btn');
     const addCategoryBtn = document.querySelector('.add-category-btn');
+    const uploadDbBtn = document.querySelector('.update-to-db-btn');
+    const updateDbBtn = document.querySelector('.update-db-btn');
 
     // Get reference to the upload button from the DOM
     const uploadBtn = document.getElementById('uploadSyllabusBtn');
 
     editBtn.onclick = () => {
         isEditMode = true;
-        backupData = JSON.parse(JSON.stringify(data));
+        backupData = JSON.parse(JSON.stringify(syllabusData));
         editBtn.style.display = 'none';
+        updateDbBtn.style.display = 'none';
         cancelBtn.style.display = 'inline';
+        uploadDbBtn.style.display = 'inline';
         doneBtn.style.display = 'inline';
+        uploadBtn.style.display = 'inline-block';
         document.body.classList.add('edit-mode');
         document.querySelector('.add-category-btn').style.display = 'block';
-
-        // Show Upload Button in Edit Mode
-        if (uploadBtn) {
-            uploadBtn.style.display = 'inline-block';
-        }
     };
 
     cancelBtn.onclick = async () => {
@@ -112,14 +196,12 @@ function setupEditControls() {
         backupData = null;
         editBtn.style.display = 'inline';
         cancelBtn.style.display = 'none';
+        uploadDbBtn.style.display = 'none';
+        uploadBtn.style.display = 'none';
         doneBtn.style.display = 'none';
         document.body.classList.remove('edit-mode');
         document.querySelector('.add-category-btn').style.display = 'none';
-
-        // Hide Upload Button when done editing
-        if (uploadBtn) {
-            uploadBtn.style.display = 'none';
-        }
+        showUpdateButtonIfAppl();
     };
 
     addCategoryBtn.onclick = async () => {
@@ -127,27 +209,22 @@ function setupEditControls() {
             name: 'New Category',
             items: []
         };
-        data.categories.push(newCategory);
-        const section = createSection(newCategory.name, [], newCategory, data);
+        syllabusData.categories.push(newCategory);
+        const section = createSection(newCategory.name, [], newCategory, syllabusData);
         main.appendChild(section);
-        await saveCourseData(new URLSearchParams(window.location.search).get('courseId'), data);
+        await saveCourseData(new URLSearchParams(window.location.search).get('courseId'), syllabusData);
         // Trigger edit of the new category name
         section.querySelector('h2').click();
     };
+
+    updateDbBtn.addEventListener('click', updateFromDatabase);
+    uploadDbBtn.addEventListener('click', uploadToDatabase);
 }
 
-document.addEventListener('DOMContentLoaded', async () => {
-    const urlParams = new URLSearchParams(window.location.search);
-    const courseId = urlParams.get('courseId') || 'unknown';
+// display the syllabus data on the page
+function displaySyllabusData(data) {
+    main.innerHTML = '';
 
-    // Load saved data
-    data = await loadCourseData(courseId);
-    console.log('Loaded data structure:', data);
-
-    // Setup edit controls
-    setupEditControls();
-
-    // Dynamically create sections
     data.categories.forEach(category => {
         const items = category.items.map(item => [item.type, item.text]);
         const section = createSection(category.name, items, category, data);
@@ -155,6 +232,18 @@ document.addEventListener('DOMContentLoaded', async () => {
     });
 
     enableDragDrop(main, data);
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
+
+    // Load saved data including server comparison
+    await loadInitialData(courseId);
+    console.log('Loaded data structure:', syllabusData);
+
+    // Setup edit controls
+    setupEditControls();
+
+    displaySyllabusData(syllabusData);
 
     // Setup for file uploading
     const uploadBtn = document.getElementById("uploadSyllabusBtn");
@@ -212,56 +301,28 @@ document.addEventListener('DOMContentLoaded', async () => {
 
 
     }
-    
-    const updateDbBtn = document.querySelector('.update-db-btn');
-    updateDbBtn.addEventListener('click', updateFromDatabase);
 });
 
+// Modify the updateFromDatabase function to properly update reference data
 async function updateFromDatabase() {
-    try {
-        const urlParams = new URLSearchParams(window.location.search);
-        const courseId = urlParams.get('courseId');
+    // Save old data as backup
+    backupData = syllabusData;
+    console.log('Backup data:', backupData);
+    
+    // Then update local data and display
+    syllabusData = structuredClone(window.serverSyllabusData);
+    await saveCourseData(courseId, syllabusData);
+    displaySyllabusData(syllabusData);
 
-        if (!courseId) {
-            alert('No course ID found in URL');
-            return;
-        }
+    // Switch to edit mode if User wants to revert
+    isEditMode = true;
+    document.querySelector('.edit-mode-btn').style.display = 'none';
+    document.querySelector('.cancel-btn').style.display = 'inline';
+    document.querySelector('.done-btn').style.display = 'inline';
+    document.querySelector('.update-db-btn').style.display = 'none';
 
-        const response = await fetch(`https://web.engr.oregonstate.edu/~ludwigo/cs362/api/syllabus-data.php?courseId=${courseId}`);
-        
-        if (!response.ok) {
-            throw new Error('Network response was not ok');
-        }
-
-        const fetchedData = await response.json();
-        console.log('Fetched data:', fetchedData);
-
-        // Check if we received valid data structure
-        if (!fetchedData.categories) {
-            throw new Error('Invalid data structure received from server');
-        }
-
-        // Save the fetched data to local storage
-        await saveCourseData(courseId, fetchedData);
-        
-        // Update the UI
-        const syllabusCategories = document.getElementById('syllabus-categories');
-        syllabusCategories.innerHTML = ''; // Clear existing content
-        
-        // Create sections for each category
-        fetchedData.categories.forEach(category => {
-            const items = category.items.map(item => [item.type, item.text]);
-            const section = createSection(category.name, items, category, fetchedData);
-            syllabusCategories.appendChild(section);
-        });
-
-        // Update our current data reference
-        data = fetchedData;
-
-    } catch (error) {
-        console.error('Error updating from database:', error);
-        alert('Failed to update from database. Please try again.');
-    }
+    // After updating from database, update the server data reference
+    showUpdateButtonIfAppl();
 }
 
 function createCategorySection(category) {
@@ -689,5 +750,44 @@ async function updateItemOrder(data) {
 
     if (updated) {
         await saveCourseData(new URLSearchParams(window.location.search).get('courseId'), data);
+    }
+}
+
+// Add this new function
+async function uploadToDatabase() {
+    try {
+        const response = await fetch('https://web.engr.oregonstate.edu/~ludwigo/cs362/api/syllabus-data.php', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+                courseId: courseId,
+                data: syllabusData
+            })
+        });
+
+        if (!response.ok) {
+            throw new Error('Network response was not ok');
+        }
+
+        // Update server reference data
+        window.serverSyllabusData = structuredClone(syllabusData);
+        
+        // Exit edit mode (similar to done button)
+        isEditMode = false;
+        backupData = null;
+        document.querySelector('.edit-mode-btn').style.display = 'inline';
+        document.querySelector('.cancel-btn').style.display = 'none';
+        document.querySelector('.update-to-db-btn').style.display = 'none';
+        document.getElementById('uploadSyllabusBtn').style.display = 'none';
+        document.querySelector('.done-btn').style.display = 'none';
+        document.body.classList.remove('edit-mode');
+        document.querySelector('.add-category-btn').style.display = 'none';
+        showUpdateButtonIfAppl();
+
+    } catch (error) {
+        console.error('Error uploading to database:', error);
+        alert('Failed to upload changes. Please try again.');
     }
 }

--- a/PainterExtension/SideMenu/standardized_syllabus.css
+++ b/PainterExtension/SideMenu/standardized_syllabus.css
@@ -29,7 +29,7 @@ a.standard-syllabus.standardized-syllabus-feature {
     box-shadow: 0 0 10px rgba(0,0,0,0.3);
     width: 90%;
     height: 90vh;
-    max-width: 1000px;
+    max-width: 900px;
 }
 
 .popup-controls {

--- a/standardSyllabusWebsite/create_table.sql
+++ b/standardSyllabusWebsite/create_table.sql
@@ -1,7 +1,5 @@
 CREATE TABLE IF NOT EXISTS syllabi (
     course_id VARCHAR(50) PRIMARY KEY,
     syllabus_data JSON,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     INDEX idx_course_id (course_id)
 );

--- a/standardSyllabusWebsite/create_table.sql
+++ b/standardSyllabusWebsite/create_table.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS syllabi (
+    course_id VARCHAR(50) PRIMARY KEY,
+    syllabus_data JSON,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_course_id (course_id)
+);

--- a/standardSyllabusWebsite/db-connector.php
+++ b/standardSyllabusWebsite/db-connector.php
@@ -1,0 +1,18 @@
+<?php
+// display errors
+ini_set('display_errors', 1);
+ini_set('display_startup_errors', 1);
+error_reporting(E_ALL);
+$host = 'localhost';
+$dbname = 'test';
+$username = 'root';
+$password = '';
+
+try {
+    $db = new PDO("mysql:host=$host;dbname=$dbname", $username, $password);
+    $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+} catch(PDOException $e) {
+    echo "Connection failed: " . $e->getMessage();
+    exit();
+}
+?>

--- a/standardSyllabusWebsite/syllabus-data.php
+++ b/standardSyllabusWebsite/syllabus-data.php
@@ -41,6 +41,22 @@ try {
                             ['type' => 'Email', 'text' => ''],
                             ['type' => 'Office Hours', 'text' => '']
                         ]
+                    ],
+                    [
+                        'name' => 'Course Policies',
+                        'items' => [
+                            ['type' => 'Attendance', 'text' => ''],
+                            ['type' => 'Late Work', 'text' => '']
+                        ]
+                    ],
+                    [
+                        'name' => 'Grading',
+                        'items' => [
+                            ['type' => 'Assignments', 'text' => ''],
+                            ['type' => 'Midterm', 'text' => ''],
+                            ['type' => 'Final Project', 'text' => ''],
+                            ['type' => 'Participation', 'text' => '']
+                        ]
                     ]
                 ]
             ]);
@@ -59,11 +75,10 @@ try {
 
         // Try to update existing record first
         $stmt = $db->prepare("
-            INSERT INTO syllabi (course_id, syllabus_data, updated_at) 
-            VALUES (?, ?, NOW()) 
+            INSERT INTO syllabi (course_id, syllabus_data) 
+            VALUES (?, ?) 
             ON DUPLICATE KEY UPDATE 
-                syllabus_data = VALUES(syllabus_data),
-                updated_at = VALUES(updated_at)
+                syllabus_data = VALUES(syllabus_data)
         ");
 
         $stmt->execute([$courseId, $syllabusData]);

--- a/standardSyllabusWebsite/syllabus-data.php
+++ b/standardSyllabusWebsite/syllabus-data.php
@@ -1,0 +1,81 @@
+<?php
+header('Content-Type: application/json');
+header('Access-Control-Allow-Origin: *');
+header('Access-Control-Allow-Methods: GET, POST');
+header('Access-Control-Allow-Headers: Content-Type');
+
+require_once('db-connector.php');
+
+// Handle preflight requests
+if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
+    http_response_code(200);
+    exit();
+}
+
+try {
+    if ($_SERVER['REQUEST_METHOD'] === 'GET') {
+        // Get course ID from query parameters
+        $courseId = isset($_GET['courseId']) ? $_GET['courseId'] : null;
+        
+        if (!$courseId) {
+            throw new Exception('Course ID is required');
+        }
+
+        // Prepare and execute query to get syllabus data
+        $stmt = $db->prepare("SELECT syllabus_data FROM syllabi WHERE course_id = ?");
+        $stmt->execute([$courseId]);
+        $result = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if ($result) {
+            echo $result['syllabus_data']; // Already in JSON format
+        } else {
+            // Return default structure if no data exists
+            echo json_encode([
+                'version' => '0.1.1',
+                'categories' => [
+                    [
+                        'name' => 'Course Information',
+                        'items' => [
+                            ['type' => 'Course Title', 'text' => ''],
+                            ['type' => 'Professor', 'text' => ''],
+                            ['type' => 'Email', 'text' => ''],
+                            ['type' => 'Office Hours', 'text' => '']
+                        ]
+                    ]
+                ]
+            ]);
+        }
+    } 
+    elseif ($_SERVER['REQUEST_METHOD'] === 'POST') {
+        // Get POST data
+        $input = json_decode(file_get_contents('php://input'), true);
+        
+        if (!isset($input['courseId']) || !isset($input['data'])) {
+            throw new Exception('Course ID and data are required');
+        }
+
+        $courseId = $input['courseId'];
+        $syllabusData = json_encode($input['data']); // Convert to JSON string for storage
+
+        // Try to update existing record first
+        $stmt = $db->prepare("
+            INSERT INTO syllabi (course_id, syllabus_data, updated_at) 
+            VALUES (?, ?, NOW()) 
+            ON DUPLICATE KEY UPDATE 
+                syllabus_data = VALUES(syllabus_data),
+                updated_at = VALUES(updated_at)
+        ");
+
+        $stmt->execute([$courseId, $syllabusData]);
+
+        echo json_encode(['status' => 'success', 'message' => 'Syllabus data saved successfully']);
+    }
+    else {
+        throw new Exception('Invalid request method');
+    }
+} 
+catch (Exception $e) {
+    http_response_code(400);
+    echo json_encode(['status' => 'error', 'message' => $e->getMessage()]);
+}
+?>


### PR DESCRIPTION
### Update Standard Syllabus to use database for sharing syllabus information
- Added update button to standard syllabus
   - Updates local syllabus with data from shared database (shared with all users, different syllabus for each course ID)
   - button will only show when there is a difference between local and db syllabus
- Added upload changes button to send changes to database
- New syllabi (like when looking at syllabus for first time in new class) will load from database, meaning it could get other user's filled data